### PR TITLE
Remove enum dependecny from NavigationService

### DIFF
--- a/TestDI.Tests/Services/NavigationServiceTests.cs
+++ b/TestDI.Tests/Services/NavigationServiceTests.cs
@@ -9,7 +9,6 @@ using NUnit.Framework;
 using TestDI.Interfaces;
 using TestDI.Navigation;
 using TestDI.Pages;
-using TestDI.Services;
 using TestDI.Tests.Fakes;
 using TestDI.Tests.Fakes.FakeXamarinForms;
 using Xamarin.Forms;

--- a/TestDI/TestDI/ClassDiagram.cd
+++ b/TestDI/TestDI/ClassDiagram.cd
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ClassDiagram MajorVersion="1" MinorVersion="1">
+  <Class Name="TestDI.MainPage" Collapsed="true">
+    <Position X="6.75" Y="1.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Pages\MainPage.xaml.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="TestDI.App" Collapsed="true">
+    <Position X="6.75" Y="0.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAABAAAAgAEAAAAAAAAAAAAgAQAAAAAAAAAAA=</HashCode>
+      <FileName>App.xaml.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="TestDI.Navigation.NavigationPageMap">
+    <Position X="11.5" Y="6" Width="2" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAA=</HashCode>
+      <FileName>Navigation\NavigationPageMap.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="TestDI.Navigation.NavigationService" BaseTypeListCollapsed="true">
+    <Position X="2.5" Y="3.5" Width="2.75" />
+    <TypeIdentifier>
+      <HashCode>AgCABAAgAACAIAAAAACAIAAgAAAQAAAAAAAAADAAAAA=</HashCode>
+      <FileName>Navigation\NavigationService.cs</FileName>
+    </TypeIdentifier>
+    <Lollipop Position="0.2" />
+  </Class>
+  <Class Name="TestDI.Navigation.NavigationServiceExtensions">
+    <Position X="8.25" Y="6" Width="2.75" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAACAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Navigation\NavigationServiceExtensions.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="TestDI.Pages.ListViewPage" Collapsed="true">
+    <Position X="8.5" Y="0.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Pages\ListViewPage.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="TestDI.Pages.LoginPage" Collapsed="true">
+    <Position X="10.25" Y="1.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Pages\LoginPage.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Class Name="TestDI.Pages.StartPage" Collapsed="true">
+    <Position X="8.5" Y="1.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Pages\StartPage.cs</FileName>
+    </TypeIdentifier>
+  </Class>
+  <Interface Name="TestDI.Interfaces.IAsyncInitialization" Collapsed="true">
+    <Position X="10.25" Y="0.5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAA=</HashCode>
+      <FileName>Interfaces\IAsyncInitialization.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="TestDI.IServiceLocator" Collapsed="true">
+    <Position X="3.25" Y="2.25" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>IoC\IServiceLocator.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Interface Name="TestDI.Navigation.INavigationService">
+    <Position X="5.5" Y="5.5" Width="2.5" />
+    <TypeIdentifier>
+      <HashCode>AAAABAAgAACAIAAAAACAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
+      <FileName>Navigation\INavigationService.cs</FileName>
+    </TypeIdentifier>
+  </Interface>
+  <Enum Name="TestDI.ApplicationPage" Collapsed="true">
+    <Position X="11.75" Y="5" Width="1.5" />
+    <TypeIdentifier>
+      <HashCode>AAAAAAAIAAAAAAAAAAAAAAAAAAAAAAEAgAAAAAAAAQA=</HashCode>
+      <FileName>ApplicationPage.cs</FileName>
+    </TypeIdentifier>
+  </Enum>
+  <Font Name="Segoe UI" Size="9" />
+</ClassDiagram>

--- a/TestDI/TestDI/Navigation/NavigationPageMap.cs
+++ b/TestDI/TestDI/Navigation/NavigationPageMap.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using TestDI.Pages;
+
+namespace TestDI.Navigation
+{
+    public static class NavigationPageMap
+    {
+        public static readonly Dictionary<string, Type> PageMap = new Dictionary<string, Type>
+        {
+            { ApplicationPage.MainMenuPage.ToString(), typeof(MainPage) },
+            { ApplicationPage.SideBar.ToString(), typeof(StartPage) },
+            { ApplicationPage.LoginPage.ToString(), typeof(LoginPage) },
+            { ApplicationPage.ListViewPage.ToString(), typeof(ListViewPage) },
+        };
+    }
+}

--- a/TestDI/TestDI/Navigation/NavigationService.cs
+++ b/TestDI/TestDI/Navigation/NavigationService.cs
@@ -2,23 +2,15 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using TestDI.Navigation;
-using TestDI.Pages;
 using Xamarin.Forms;
 
-namespace TestDI.Services
+namespace TestDI.Navigation
 {
     public class NavigationService : INavigationService
     {
         private readonly INavigation _pageNavigation;
         private readonly IServiceLocator _serviceLocator;
         private readonly Dictionary<string, object> _naivagionParameters;
-        private readonly Dictionary<ApplicationPage, Type> _applicationPages = new Dictionary<ApplicationPage, Type>
-        {
-            { ApplicationPage.MainMenuPage, typeof(MainPage) },
-            { ApplicationPage.SideBar, typeof(StartPage) },
-            { ApplicationPage.LoginPage, typeof(LoginPage) },
-            { ApplicationPage.ListViewPage, typeof(ListViewPage) },
-        };
 
         public NavigationService(INavigation navigation, IServiceLocator serviceLocator)
         {
@@ -93,10 +85,7 @@ namespace TestDI.Services
         }
 
         private Page GetNewPage(string destinationPageName)
-        {
-            Enum.TryParse(destinationPageName, out ApplicationPage applicationPage);
-            return (Page)_serviceLocator.Get(_applicationPages[applicationPage]);
-        }
+            => (Page)_serviceLocator.Get(NavigationPageMap.PageMap[destinationPageName]);
 
         private Page GetPage(int index)
             => _pageNavigation.NavigationStack[index];


### PR DESCRIPTION
To ensure that it can be used in any case not only with registered
ApplicationPage Enum.